### PR TITLE
Add fzf support for interactive project selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Just type part of a project name and press `<TAB>` to complete it.
 
 - [x] Add flag to open projects directly in VS Code.  
 - [ ] Add support for more editors (JetBrains, Sublime, etc.).  
-- [ ] Add fuzzy search for project names.  
+- [x] Add fuzzy search for project names.  
 - [ ] Add aliases or shortcuts per project.
 
 ---

--- a/zsh-dev-navigator.plugin.zsh
+++ b/zsh-dev-navigator.plugin.zsh
@@ -20,7 +20,7 @@ dev() {
     if [ -z "$project_name" ]; then
         if [[ -d "$DEV_BASE_DIR" ]]; then
             if command -v fzf >/dev/null 2>&1; then
-                project_name=$(ls -1 "$DEV_BASE_DIR" | fzf --height 40% --border --prompt="Select project: ")
+                project_name=$(ls -1 "$DEV_BASE_DIR" | fzf --height 40% --border --prompt="Select project: " --bind "ctrl-c:abort" --header="Press ESC to open root dev folder")
             fi
         else
             echo "DEV base directory not found: $DEV_BASE_DIR" >&2

--- a/zsh-dev-navigator.plugin.zsh
+++ b/zsh-dev-navigator.plugin.zsh
@@ -18,6 +18,17 @@ dev() {
     done
 
     if [ -z "$project_name" ]; then
+        if [[ -d "$DEV_BASE_DIR" ]]; then
+            if command -v fzf >/dev/null 2>&1; then
+                project_name=$(ls -1 "$DEV_BASE_DIR" | fzf --height 40% --border --prompt="Select project: ")
+            fi
+        else
+            echo "DEV base directory not found: $DEV_BASE_DIR" >&2
+            return 1
+        fi
+    fi
+
+    if [ -z "$project_name" ]; then
         local target_dir="$DEV_BASE_DIR"
     else
         local target_dir="$DEV_BASE_DIR/$project_name"


### PR DESCRIPTION
**Improvements:**
- Detects if fzf is installed and automatically enables interactive project selection when running dev or dev -o without arguments.
- Maintains backward compatibility for users without fzf.

This enhancement makes it easier to navigate and open projects, providing a fast, searchable interface for development directories.