### PR TITLE
✨ Feature: Add -cg flag to create directories with git initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ dev -c new-project
 # → Creates ~/dev/new-project and navigates to it
 ```
 
+Create a new project with git repository:
+
+```bash
+dev -cg new-project
+# → Creates ~/dev/new-project, initializes git, and navigates to it
+```
+
 ---
 
 ## ✨ Features
@@ -34,7 +41,8 @@ dev -c new-project
 - 📁 Smart **recursive autocompletion** for subfolders.  
 - 🧭 Defaults to your base development folder when no argument is provided.  
 - 🪄 Optional **flags** to extend functionality — e.g., open projects directly in your **preferred editor**.  
-- 🆕 **Create new project directories** on-the-fly with the `-c` flag.  
+- 🆕 **Create new project directories** on-the-fly with the `-c` flag.
+- 🔧 **Initialize git repositories** automatically with the `-cg` flag.  
 - ⚙️ **Configurable** base directory and default editor via configuration file.  
 - 🔍 **Fuzzy finder integration** (fzf) for interactive project selection when no argument is provided.  
 - 🎯 Support for **multiple editors**: VS Code, Cursor, Windsurf, Sublime Text, Vim, and more.  
@@ -104,6 +112,12 @@ dev
 ```bash
 dev -c new-project
 # → Creates ~/dev/new-project and navigates to it
+```
+
+**Create new project with git:**  
+```bash
+dev -cg new-project
+# → Creates ~/dev/new-project, initializes git, and navigates to it
 ```
 
 ---
@@ -186,11 +200,21 @@ dev -c new-project
 # → Creates ~/dev/new-project and navigates to it
 ```
 
+Create a new project with git repository:
+
+```bash
+dev -cg new-project
+# → Creates ~/dev/new-project, initializes git, and navigates to it
+```
+
 Combine flags:
 
 ```bash
 dev -c -o new-app
 # → Creates ~/dev/new-app and opens it in your configured editor
+
+dev -cg -o new-git-project
+# → Creates ~/dev/new-git-project, initializes git, and opens it in your editor
 ```
 
 ---

--- a/zsh-dev-navigator.plugin.zsh
+++ b/zsh-dev-navigator.plugin.zsh
@@ -7,6 +7,7 @@ EDITOR_CMD=$(grep -E '^\s*editor\s*=' "$DEV_CONFIG_FILE" | cut -d '=' -f2- | xar
 dev() {
     local open_in_editor=false
     local create_directory=false
+    local git_init=false
     local project_name=""
 
     while [[ $# -gt 0 ]]; do
@@ -17,6 +18,11 @@ dev() {
                 ;;
             -c|--create)
                 create_directory=true
+                shift
+                ;;
+            -cg|--create-git)
+                create_directory=true
+                git_init=true
                 shift
                 ;;
             *)
@@ -51,6 +57,14 @@ dev() {
                 echo "Failed to create directory: $target_dir" >&2
                 return 1
             }
+            
+            # Initialize git repository if -cg flag was used
+            if [ "$git_init" = true ]; then
+                echo "Initializing git repository..."
+                (cd "$target_dir" && git init) || {
+                    echo "Warning: Failed to initialize git repository" >&2
+                }
+            fi
         else
             echo "Project not found: $target_dir" >&2
             return 1
@@ -72,6 +86,7 @@ _dev_completions() {
     _arguments -C \
         '(-o --open)'{-o,--open}'[Open directory in default editor]' \
         '(-c --create)'{-c,--create}'[Create directory if it does not exist]' \
+        '(-cg --create-git)'{-cg,--create-git}'[Create directory and initialize git repository]' \
         '*:project:->projects' && return 0
 
     case $state in


### PR DESCRIPTION
## 🎯 Overview

This PR adds a new `-cg` flag that combines directory creation with automatic git repository initialization, streamlining the workflow for creating new development projects.

## ✨ What's New

### New `-cg` Flag
- **Combined functionality**: Creates directory AND initializes git repository in one command
- **Smart error handling**: Shows warning if git init fails but continues execution
- **Autocompletion support**: Added `-cg/--create-git` to zsh completions
- **Flexible usage**: Can be combined with other flags like `-o` for editor opening

### Usage Examples
```bash
# Create project with git repository
dev -cg my-new-project

# Create project with git and open in editor
dev -cg -o my-new-project

# Long form also supported
dev --create-git my-new-project