### PR TITLE
Feat: Add configurable auto_git_init option for automatic git initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ dev -cg new-project
 - 🆕 **Create new project directories** on-the-fly with the `-c` flag.
 - 🔧 **Initialize git repositories** automatically with the `-cg` flag.  
 - ⚙️ **Configurable** base directory and default editor via configuration file.  
+- 🤖 **Auto git init** option to initialize git repositories with `-c` flag automatically.  
 - 🔍 **Fuzzy finder integration** (fzf) for interactive project selection when no argument is provided.  
 - 🎯 Support for **multiple editors**: VS Code, Cursor, Windsurf, Sublime Text, Vim, and more.  
 
@@ -138,6 +139,10 @@ dev_directory = ~/dev
 # Default editor to use with the -o flag
 # Supported editors: code, cursor, windsurf, subl, vim, nvim, emacs, atom, webstorm, idea, pycharm
 editor = code
+
+# Automatically initialize git repository when creating new directories with -c flag
+# Set to true to enable automatic git init, false to disable
+auto_git_init = false
 ```
 
 ### Customizing Settings
@@ -161,6 +166,12 @@ editor = code
 3. **Custom Editor Path**: You can also specify a full path to a custom editor:
    ```bash
    editor = /usr/local/bin/my-custom-editor
+   ```
+
+4. **Automatic Git Initialization**: Enable automatic `git init` when creating directories with `-c`:
+   ```bash
+   auto_git_init = true   # Always initialize git with -c flag
+   auto_git_init = false  # Only initialize git with -cg flag (default)
    ```
 
 ---
@@ -206,6 +217,8 @@ Create a new project with git repository:
 dev -cg new-project
 # → Creates ~/dev/new-project, initializes git, and navigates to it
 ```
+
+**Note**: If you have `auto_git_init = true` in your config, then `dev -c new-project` will also initialize git automatically.
 
 Combine flags:
 

--- a/config
+++ b/config
@@ -9,5 +9,9 @@ dev_directory = ~/dev
 # Supported editors: code, cursor, windsurf, subl, vim, nvim, emacs, atom, webstorm, idea, pycharm
 editor = code
 
+# Automatically initialize git repository when creating new directories with -c flag
+# Set to true to enable automatic git init, false to disable
+auto_git_init = false
+
 # You can also specify custom editors with full paths
 # editor = /usr/local/bin/my-custom-editor

--- a/zsh-dev-navigator.plugin.zsh
+++ b/zsh-dev-navigator.plugin.zsh
@@ -3,6 +3,7 @@ DEV_CONFIG_FILE="$PLUGIN_DIR/config"
 
 DEV_BASE_DIR=$(grep -E '^\s*dev_directory\s*=' "$DEV_CONFIG_FILE" | cut -d '=' -f2- | xargs | sed "s|~|$HOME|")
 EDITOR_CMD=$(grep -E '^\s*editor\s*=' "$DEV_CONFIG_FILE" | cut -d '=' -f2- | xargs)
+AUTO_GIT_INIT=$(grep -E '^\s*auto_git_init\s*=' "$DEV_CONFIG_FILE" | cut -d '=' -f2- | xargs)
 
 dev() {
     local open_in_editor=false
@@ -58,8 +59,8 @@ dev() {
                 return 1
             }
             
-            # Initialize git repository if -cg flag was used
-            if [ "$git_init" = true ]; then
+            # Initialize git repository if -cg flag was used OR if auto_git_init is enabled
+            if [ "$git_init" = true ] || [ "$AUTO_GIT_INIT" = "true" ]; then
                 echo "Initializing git repository..."
                 (cd "$target_dir" && git init) || {
                     echo "Warning: Failed to initialize git repository" >&2


### PR DESCRIPTION
## 🎯 Overview

This PR introduces a configurable `auto_git_init` option that allows users to automatically initialize git repositories when creating directories with the `-c` flag, providing a more streamlined workflow for users who always want git initialization.

## ✨ What's New

### Configurable Auto Git Init
- **New config option**: `auto_git_init = true/false` in the config file
- **Smart behavior**: When enabled, `-c` flag automatically includes `git init`
- **User choice**: Users can choose their preferred workflow via configuration
- **Backward compatible**: Disabled by default to maintain existing behavior

### Configuration Options
```bash
# Enable automatic git init with -c flag
auto_git_init = true

# Disable automatic git init (default behavior)
auto_git_init = false